### PR TITLE
Fix for N-to-A conversion appearing in gene annotations

### DIFF
--- a/src/circularity.jl
+++ b/src/circularity.jl
@@ -132,15 +132,20 @@ end
 struct CircularSequence
     length::Int32
     sequence::LongDNA{2}
+    original_sequence::LongDNA{4}  # Store original sequence with N characters preserved
     mask::CircularMask  #used to mask low entropy regions, ambiguous bases, gaps
 
     function CircularSequence(seq::LongDNA{2}, mask::CircularMask)
-        new(length(seq), append!(seq, LongSubSeq(seq, 1:length(seq)-1)), mask)
+        # For this constructor, we don't have the original sequence, so create a dummy one
+        original_seq = LongDNA{4}(seq)
+        new(length(seq), append!(seq, LongSubSeq(seq, 1:length(seq)-1)), original_seq, mask)
     end
 
     function CircularSequence(seq::LongDNA{4})
         mask = CircularMask(falses(length(seq)))
         entropy_mask!(seq, mask)
+        # Store original sequence before modification
+        original_seq = copy(seq)
         for (n::Int32, nt) in enumerate(seq)
             if isambiguous(nt) || isgap(nt)
                 setindex!(mask, true, n)
@@ -148,12 +153,17 @@ struct CircularSequence
             end
         end
         compressedseq = LongDNA{2}(seq)
-        new(length(compressedseq), append!(compressedseq, LongSubSeq(compressedseq, 1:length(compressedseq)-1)), mask)
+        new(length(compressedseq), append!(compressedseq, LongSubSeq(compressedseq, 1:length(compressedseq)-1)), original_seq, mask)
     end
 end
 
 @inline Base.length(cs::CircularSequence) = cs.length
 @inline Base.getindex(cs::CircularSequence, i::Int32) = @inbounds getindex(cs.sequence, mod1(i, cs.length))
+
+# Function to get the original sequence with N characters preserved
+function get_original_sequence(cs::CircularSequence)
+    return cs.original_sequence[1:cs.length]
+end
 
 function Base.getindex(cs::CircularSequence, r::UnitRange{<:Integer})
     @assert length(r) <= length(cs)

--- a/src/output_formats.jl
+++ b/src/output_formats.jl
@@ -187,7 +187,7 @@ end
 function write_result(config::ChloeConfig, target::FwdRev{CircularSequence}, result::ChloeAnnotation, filestem::String)::Tuple{Union{String,IO},String}
     if ~config.no_transform
         FASTAWriter(open(filestem * ".chloe.fa", "w")) do outfile
-            write(outfile, FASTARecord(result.target_id, target.forward[1:length(target.forward)]))
+            write(outfile, FASTARecord(result.target_id, get_original_sequence(target.forward)))
         end
     end
     if config.sff
@@ -204,12 +204,12 @@ function write_result(config::ChloeConfig, target::FwdRev{CircularSequence}, res
         if config.gbk
             out = filestem * ".chloe.gbk"
             biojulia.header = "LOCUS       $(rpad(result.target_id, 10, ' ')) $(lpad(length(biojulia.sequence), 10, ' ')) bp    DNA     circular PLN $(uppercase(Dates.format(now(), "dd-uuu-yyyy")))"
-            biojulia.sequence = target.forward[1:length(target.forward)]
+            biojulia.sequence = get_original_sequence(target.forward)
             GenBank.printgbk(out, biojulia)
         end
         if config.embl
             out = filestem * ".chloe.embl"
-            biojulia.sequence = target.forward[1:length(target.forward)]
+            biojulia.sequence = get_original_sequence(target.forward)
             EMBL.printembl(out, biojulia)
         end
     end


### PR DESCRIPTION
Retain any `N` characters from an input fasta sequence in output FASTA/Genbank/EMBL files, even if they appear is gene annotations, rather than converted `A` characters. 