### PR TITLE
fixed seq length bug; updated gbk header

### DIFF
--- a/src/output_formats.jl
+++ b/src/output_formats.jl
@@ -203,8 +203,9 @@ function write_result(config::ChloeConfig, target::FwdRev{CircularSequence}, res
         end
         if config.gbk
             out = filestem * ".chloe.gbk"
-            biojulia.header = "LOCUS       $(rpad(result.target_id, 10, ' ')) $(lpad(length(biojulia.sequence), 10, ' ')) bp    DNA     circular PLN $(uppercase(Dates.format(now(), "dd-uuu-yyyy")))"
             biojulia.sequence = target.forward[1:length(target.forward)]
+            spaces = 29 - length(result.target_id) - length(length(biojulia.sequence))
+            biojulia.header = "LOCUS       $(result.target_id)$(lpad(length(biojulia.sequence), spaces, " ")) bp     DNA    circular PLN $(uppercase(Dates.format(now(), "dd-uuu-yyyy")))"
             GenBank.printgbk(out, biojulia)
         end
         if config.embl


### PR DESCRIPTION
Previous changes (43ab76ad7a80d187221eea185394fe959f4fae18) meant that GenBank headers incorrectly reported sequence length of 0, since `biojulia.sequence` hadn't been defined yet. I moved the order of the variable assignment to fix this.

Secondly, I adjusted the whitespace in the header so that it fits the expected format for parsing with Biopython.

I'm not versed in Julia, so hopefully the changes use appropriate syntax. I've tested the resulting build and it works as expected for my data.