### PR TITLE
adjusting features for output_formats.jl, adding product

### DIFF
--- a/src/output_formats.jl
+++ b/src/output_formats.jl
@@ -83,7 +83,125 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
     biojulia.circular = true
     # add
 
+    # define a product dictionary (not sure this is the right place to do this)
+    product_dict = Dict(
+        "accD"=>"acetyl-coenzyme A carboxylase carboxyl transferase subunit beta",
+        "atpA"=>"ATP synthase subunit alpha",
+        "atpB"=>"ATP synthase subunit beta",
+        "atpE"=>"ATP synthase epsilon chain",
+        "atpF"=>"ATP synthase subunit b",
+        "atpH"=>"ATP synthase subunit c",
+        "atpI"=>"ATP synthase subunit a",
+        "ccsA"=>"cytochrome c biogenesis protein",
+        "cemA"=>"potassium/proton antiporter",
+        "clpP1"=>"chloroplastic ATP-dependent Clp protease proteolytic subunit 1",
+        "infA"=>"translation initiation factor IF-1",
+        "matK"=>"maturase K",
+        "ndhA"=>"NAD(P)H-quinone oxidoreductase subunit 1",
+        "ndhB"=>"NAD(P)H-quinone oxidoreductase subunit 2",
+        "ndhC"=>"NAD(P)H-quinone oxidoreductase subunit 3",
+        "ndhD"=>"NAD(P)H-quinone oxidoreductase chain 4",
+        "ndhE"=>"NAD(P)H-quinone oxidoreductase subunit 4L",
+        "ndhF"=>"NAD(P)H-quinone oxidoreductase subunit 5",
+        "ndhG"=>"NAD(P)H-quinone oxidoreductase subunit 6",
+        "ndhH"=>"NAD(P)H-quinone oxidoreductase subunit H",
+        "ndhI"=>"NAD(P)H-quinone oxidoreductase subunit I",
+        "ndhJ"=>"NAD(P)H-quinone oxidoreductase subunit J",
+        "ndhK"=>"NAD(P)H-quinone oxidoreductase subunit K",
+        "pafI"=>"photosystem I assembly protein Ycf3",
+        "pafII"=>"photosystem I assembly protein Ycf4",
+        "pbf1"=>"photosystem biogenesis factor 1",
+        "petA"=>"cytochrome f",
+        "petB"=>"cytochrome b6",
+        "petD"=>"cytochrome b6-f complex subunit 4 ",
+        "petG"=>"cytochrome b6-f complex subunit 5",
+        "petL"=>"cytochrome b6-f complex subunit 6",
+        "petN"=>"cytochrome b6-f complex subunit 8",
+        "psaA"=>"photosystem I P700 chlorophyll a apoprotein A1",
+        "psaB"=>"photosystem I P700 chlorophyll a apoprotein A2",
+        "psaC"=>"photosystem I iron-sulfur center",
+        "psaI"=>"photosystem I reaction center subunit VIII",
+        "psaJ"=>"photosystem I reaction center subunit IX",
+        "psbA"=>"photosystem II protein D1",
+        "psbB"=>"photosystem II CP47 reaction center protein",
+        "psbC"=>"photosystem II CP43 reaction center protein",
+        "psbD"=>"photosystem II D2 protein",
+        "psbE"=>"cytochrome b559 subunit alpha",
+        "psbF"=>"cytochrome b559 subunit beta",
+        "psbH"=>"photosystem II reaction center protein H",
+        "psbI"=>"photosystem II reaction center protein I",
+        "psbJ"=>"photosystem II reaction center protein J",
+        "psbK"=>"photosystem II reaction center protein K",
+        "psbL"=>"photosystem II reaction center protein L",
+        "psbM"=>"photosystem II reaction center protein M",
+        "psbT"=>"photosystem II reaction center protein T",
+        "psbZ"=>"photosystem II reaction center protein Z",
+        "rbcL"=>"ribulose bisphosphate carboxylase large chain",
+        "rpl14"=>"large ribosomal subunit protein uL14c",
+        "rpl16"=>"large ribosomal subunit protein uL16c",
+        "rpl2"=>"large ribosomal subunit protein uL2cz/uL2cy",
+        "rpl20"=>"large ribosomal subunit protein bL20c",
+        "rpl22"=>"large ribosomal subunit protein uL22c",
+        "rpl23"=>"large ribosomal subunit protein uL23cz/uL23cy",
+        "rpl32"=>"large ribosomal subunit protein bL32c",
+        "rpl33"=>"large ribosomal subunit protein bL33c",
+        "rpl36"=>"large ribosomal subunit protein bL36c",
+        "rpoA"=>"DNA-directed RNA polymerase subunit alpha",
+        "rpoB"=>"DNA-directed RNA polymerase subunit beta",
+        "rpoC1"=>"DNA-directed RNA polymerase subunit beta'",
+        "rpoC2"=>"DNA-directed RNA polymerase subunit beta''",
+        "rps11"=>"small ribosomal subunit protein uS11c",
+        "rps12"=>"small ribosomal subunit protein uS12cz/uS12cy",
+        "rps14"=>"small ribosomal subunit protein uS14c",
+        "rps15"=>"small ribosomal subunit protein uS15c",
+        "rps16"=>"small ribosomal subunit protein uS16c",
+        "rps18"=>"small ribosomal subunit protein uS18c",
+        "rps19"=>"small ribosomal subunit protein uS19c",
+        "rps2"=>"small ribosomal subunit protein uS2c",
+        "rps3"=>"small ribosomal subunit protein uS3c",
+        "rps4"=>"small ribosomal subunit protein uS4c",
+        "rps7"=>"small ribosomal subunit protein uS7cz/uS7cy",
+        "rps8"=>"small ribosomal subunit protein uS8c",
+        "ycf1"=>"protein TIC 214",
+        "ycf2"=>"protein Ycf2",
+        "rrn16"=>"16S ribosomal RNA",
+        "rrn23"=>"23S ribosomal RNA",
+        "rrn4.5"=>"4.5S ribosomal RNA",
+        "rrn5"=>"5S ribosomal RNA",
+        "trnA-UGC"=>"tRNA-Ala",
+        "trnC-GCA"=>"tRNA-Cys",
+        "trnD-GUC"=>"tRNA-Asp",
+        "trnE-UUC"=>"tRNA-Glu",
+        "trnF-GAA"=>"tRNA-Phe",
+        "trnfM-CAU"=>"tRNA-fMet",
+        "trnG-GCC"=>"tRNA-Gly",
+        "trnG-UCC"=>"tRNA-Gly",
+        "trnH-GUG"=>"tRNA-His",
+        "trnI-CAU"=>"tRNA-Ile",
+        "trnI-GAU"=>"tRNA-Ile",
+        "trnK-UUU"=>"tRNA-Lys",
+        "trnL-CAA"=>"tRNA-Leu",
+        "trnL-UAA"=>"tRNA-Leu",
+        "trnL-UAG"=>"tRNA-Leu",
+        "trnM-CAU"=>"tRNA-Met",
+        "trnN-GUU"=>"tRNA-Asn",
+        "trnP-UGG"=>"tRNA-Pro",
+        "trnQ-UUG"=>"tRNA-Gln",
+        "trnR-ACG"=>"tRNA-Arg",
+        "trnR-UCU"=>"tRNA-Arg",
+        "trnS-GCU"=>"tRNA-Ser",
+        "trnS-GGA"=>"tRNA-Ser",
+        "trnS-UGA"=>"tRNA-Ser",
+        "trnT-GGU"=>"tRNA-Thr",
+        "trnT-UGU"=>"tRNA-Thr",
+        "trnV-GAC"=>"tRNA-Val",
+        "trnV-UAC"=>"tRNA-Val",
+        "trnW-CCA"=>"tRNA-Trp",
+        "trnY-GUA"=>"tRNA-Tyr"
+    )
+
     sffs = vcat(chloe.annotation.forward, chloe.annotation.reverse)
+    locus_index = 1
     for sff in sffs
         merge_adjacent_features!(sff)
         startswith(sff.gene, "rps12") && continue
@@ -95,14 +213,25 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
         locus = ClosedSpan(span)
         if sff.strand == '-'; locus = Complement(locus); end
         gene_id = string(uuid4())
-        addgene!(biojulia, Symbol(ft), locus; locus_tag = gene_id, ID = gene_id, gene = sff.gene, name = sff.gene)
+        locus_tag = "LOCUSTAG_" * string(locus_index) * "loc"
+        addgene!(biojulia, Symbol(ft), locus; locus_tag = locus_tag, ID = gene_id, gene = sff.gene, Name = sff.gene)
         # optionally construct mRNA feature
         # construct CDS, tRNA or rRNA feature
         for feature_type in ["CDS", "tRNA", "rRNA"]
-            locus = construct_locus(sff, feature_type, chloe.target_length)
-            if ~isnothing(locus)
-                id = string(uuid4())
-                addgene!(biojulia, Symbol(feature_type), locus; parent = gene_id, locus_tag = id, ID = id, gene = sff.gene, name = "$(sff.gene).$feature_type")
+            if feature_type == "CDS"
+                locus = construct_locus(sff, feature_type, chloe.target_length)
+                if ~isnothing(locus)
+                    id = string(uuid4())
+                    addgene!(biojulia, Symbol(feature_type), locus; Parent = gene_id, locus_tag = locus_tag, ID = id, gene = sff.gene,
+                        Name = "$(sff.gene).$feature_type", product = get(product_dict, sff.gene, "missing"), transl_table = 11)
+                end
+            else
+                locus = construct_locus(sff, feature_type, chloe.target_length)
+                if ~isnothing(locus)
+                    id = string(uuid4())
+                    addgene!(biojulia, Symbol(feature_type), locus; Parent = gene_id, locus_tag = locus_tag, ID = id, gene = sff.gene,
+                        Name = "$(sff.gene).$feature_type", product = get(product_dict, sff.gene, "missing"))
+                end
             end
         end
         # construct intron feature(s)
@@ -113,11 +242,14 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
             locus = ClosedSpan(start:start + f.length-1)
             if sff.strand == '-'; locus = Complement(locus); end
             id = string(uuid4())
-            addgene!(biojulia, :intron, locus; parent = gene_id, locus_tag = id, ID = id, gene = sff.gene, name = "$(sff.gene).intron.$i" )
+            addgene!(biojulia, :intron, locus; Parent = gene_id, locus_tag = locus_tag, ID = id, gene = sff.gene, Name = "$(sff.gene).intron.$i",
+                number = i)
         end
+        locus_index += 1
     end
     # join rps12A and rps12B features
     for a in filter(x -> x.gene == "rps12A", sffs), b in filter(x -> x.gene == "rps12B", sffs)
+        locus_tag = "LOCUSTAG_" * string(locus_index) * "loc"
         # construct gene/repeat_region feature
         aspan = gene_span(a)
         if a.strand == '-'; aspan = reverse_complement(aspan, chloe.target_length); end
@@ -128,7 +260,7 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
         blocus = ClosedSpan(bspan)
         if b.strand == '-'; blocus = Complement(blocus); end
         gene_id = string(uuid4())
-        addgene!(biojulia, :gene, Join([alocus, blocus]); locus_tag = gene_id, ID = gene_id, gene = "rps12", name = "rps12")
+        addgene!(biojulia, :gene, Join([alocus, blocus]); locus_tag = locus_tag, ID = gene_id, gene = "rps12", Name = "rps12")
         # construct CDS feature
         alocus = construct_locus(a, "CDS", chloe.target_length)
         bloci = Vector{AbstractLocus}()
@@ -139,7 +271,8 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
             push!(bloci, b.strand == '+' ? span : Complement(span))
         end
         id = string(uuid4())
-        addgene!(biojulia, :CDS, Join([alocus, bloci...]); parent = gene_id, locus_tag = id, ID = id, gene = "rps12", name = "rps12.CDS")
+        addgene!(biojulia, :CDS, Join([alocus, bloci...]); Parent = gene_id, locus_tag = locus_tag, ID = id, gene = "rps12", Name = "rps12.CDS",
+            product = "small ribosomal subunit protein uS12cz/uS12cy", transl_table = 11)
         # construct rps12A internal intron feature(s) (I don't think there are any, but just in case...)
         aintrons = filter(x -> x.feature.type == "intron", a.features)
         intron_count = 1
@@ -149,7 +282,8 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
             locus = ClosedSpan(start:start + f.length-1)
             if a.strand == '-'; locus = Complement(locus); end
             id = string(uuid4())
-            addgene!(biojulia, :intron, locus; parent = gene_id, locus_tag = id, ID = id, gene = "rps12", name = "rps12.intron.$intron_count" )
+            addgene!(biojulia, :intron, locus; Parent = gene_id, locus_tag = locus_tag, ID = id, gene = "rps12", Name = "rps12.intron.$intron_count",
+                number = intron_count)
             intron_count += 1
         end
         bintrons = filter(x -> x.feature.type == "intron", b.features)
@@ -165,7 +299,8 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
                 blocus = ClosedSpan(start:start + f.length-1)
                 if b.strand == '-'; blocus = Complement(blocus); end
                 id = string(uuid4())
-                addgene!(biojulia, :intron, Join([alocus, blocus]); parent = gene_id, locus_tag = id, ID = id, gene = "rps12", name = "rps12.intron.$intron_count" )
+                addgene!(biojulia, :intron, Join([alocus, blocus]); Parent = gene_id, locus_tag = locus_tag, ID = id, gene = "rps12",
+                    Name = "rps12.intron.$intron_count", number = intron_count)
                 intron_count += 1
             end
         end
@@ -176,7 +311,8 @@ function chloe2biojulia(chloe::ChloeAnnotation)::GenomicAnnotations.Record
             locus = ClosedSpan(start:start + f.length-1)
             if b.strand == '-'; locus = Complement(locus); end
             id = string(uuid4())
-            addgene!(biojulia, :intron, locus; parent = gene_id, locus_tag = id, ID = id, gene = "rps12", name = "rps12.intron.$intron_count" )
+            addgene!(biojulia, :intron, locus; Parent = gene_id, locus_tag = locus_tag, ID = id, gene = "rps12", Name = "rps12.intron.$intron_count",
+                number = intron_count)
             intron_count += 1
         end
     end


### PR DESCRIPTION
This set of adjustments to output_formats.jl should make it easier to generate GenBank and EMBL outputs that are more compatible with submission to GenBank and ENA. While GenBank doesn't accept straight flat files for submission, ENA does. The GenBank files might be converted to feature tables with other tools (or maybe here eventually?).

There are a few changes to the output:

1) Qualifiers "Parent" and "Name" are capitalised to match GFF3 format (although these are unnecessary for gbk and embl and will need to searched and removed; I've retained them for original function in generating GFF files).

2) Qualifier "locus_tag" is adjusted to be generic and increment with loci. While GenBank doesn't want this submitted (can be search removed), ENA does, but requires registry before submission. This could again be search and replaced.

3) The required qualifier "product" (for GenBank and ENA) is now implemented, with a product dictionary for plastid genes (from [UniProt](https://www.uniprot.org/)), rRNA and tRNAs. I'm not sure if this is the right place to put the dictionary, but it seems to work.

4) The required qualifier "transl_table" for CDS is now included.

5) Introns now include the required qualifier "number".

Outstanding issues:
- rps12 may need some adjustment (manual?) to add the "trans_splicing" qualifier. When I tried to add it, the code broke, I think because GenomicAnnotations.jl only accepts pairs of args(?), and "trans_splicing" doesn't "=" anything.
- In addition, for rps12, both versions of the gene get the same locus_tag, and I'm not sure the best way to handle this. Perhaps it will also need to be manually adjusted or...?